### PR TITLE
Allow one-digit hour for german time

### DIFF
--- a/reminder/locales.py
+++ b/reminder/locales.py
@@ -134,7 +134,7 @@ locales["de_de"] = Locale(
                                "don": TH, "fre": FR, "sam": SA, "son": SU,
                            }, substr=3),
     time=RegexMatcher(r"\s?(?:um\s)?"
-                      r"(?P<hour>\d{2})"
+                      r"(?P<hour>\d{1,2})"
                       r"[:.](?P<minute>\d{2})"
                       r"(?:[:.](?P<second>\d{2}))?"
                       r"(?:\s|$)"),


### PR DESCRIPTION
E.g. !reminder morgen um 8:30
instead of !reminder morgen um 08:30